### PR TITLE
Set cache duration in settings

### DIFF
--- a/app/src/main/java/com/thomasphillips3/dogs/util/SharedPreferencesHelper.kt
+++ b/app/src/main/java/com/thomasphillips3/dogs/util/SharedPreferencesHelper.kt
@@ -32,4 +32,6 @@ class SharedPreferencesHelper {
     }
 
     fun getUpdateTime() = prefs?.getLong(PREF_TIME, 0L)
+
+    fun getCacheDuration() = prefs?.getString("pref_cache_duration", "")
 }

--- a/app/src/main/java/com/thomasphillips3/dogs/view/ListFragment.kt
+++ b/app/src/main/java/com/thomasphillips3/dogs/view/ListFragment.kt
@@ -1,16 +1,14 @@
 package com.thomasphillips3.dogs.view
 
 import android.os.Bundle
+import android.view.*
 import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
+import androidx.navigation.Navigation
 import androidx.recyclerview.widget.LinearLayoutManager
 
 import com.thomasphillips3.dogs.R
-import com.thomasphillips3.dogs.model.DogBreed
 import com.thomasphillips3.dogs.viewmodel.ListViewModel
 import kotlinx.android.synthetic.main.fragment_list.*
 
@@ -49,6 +47,7 @@ class ListFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
+        setHasOptionsMenu(true)
         return inflater.inflate(R.layout.fragment_list, container, false)
     }
 
@@ -76,5 +75,19 @@ class ListFragment : Fragment() {
                 }
             }
         })
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.list_menu, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when(item.itemId) {
+            R.id.actionSettings -> {
+                view?.let { Navigation.findNavController(it).navigate(ListFragmentDirections.actionSettings())}
+            }
+        }
+        return super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/com/thomasphillips3/dogs/view/SettingsFragment.kt
+++ b/app/src/main/java/com/thomasphillips3/dogs/view/SettingsFragment.kt
@@ -1,0 +1,18 @@
+package com.thomasphillips3.dogs.view
+
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.preference.PreferenceFragmentCompat
+
+import com.thomasphillips3.dogs.R
+
+class SettingsFragment : PreferenceFragmentCompat() {
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.preferences, rootKey)
+    }
+}

--- a/app/src/main/res/menu/list_menu.xml
+++ b/app/src/main/res/menu/list_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:title="@string/settings"
+        android:id="@+id/actionSettings" />
+</menu>

--- a/app/src/main/res/navigation/dog_navigation.xml
+++ b/app/src/main/res/navigation/dog_navigation.xml
@@ -12,6 +12,9 @@
             app:destination="@id/detailFragment"
             app:enterAnim="@anim/nav_default_enter_anim"
             app:exitAnim="@anim/nav_default_exit_anim" />
+        <action
+            android:id="@+id/actionSettings"
+            app:destination="@+id/settingsFragment" />
     </fragment>
     <fragment
         android:id="@+id/detailFragment"
@@ -27,4 +30,8 @@
             android:defaultValue="0"
             app:argType="integer" />
     </fragment>
+    <fragment
+        android:id="@+id/settingsFragment"
+        android:name="com.thomasphillips3.dogs.view.SettingsFragment"
+        android:label="SettingsFragment" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="dog_image">Dog image</string>
     <string name="dog_purpose">Dog purpose</string>
     <string name="dog_temperament">Dog temperament</string>
+    <string name="settings">Settings</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <EditTextPreference
+        android:defaultValue="10"
+        android:selectAllOnFocus="true"
+        android:singleLine="true"
+        android:inputType="number"
+        android:title="Cache duration in seconds"
+        android:key="pref_cache_duration" />
+</PreferenceScreen>


### PR DESCRIPTION
## Background
Preferences section of [Android Jetpack masterclass](https://www.udemy.com/course/androidjetpack/learn/lecture/15184104#overview)

## Changes
* Create settings page
* Create options menu
* Create action to navigate to the Settings page
* Retrieve user's input for cache duration and set it